### PR TITLE
Change apartment to ros-apartment

### DIFF
--- a/leases.gemspec
+++ b/leases.gemspec
@@ -25,5 +25,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'with_model'
   gem.add_development_dependency 'test-unit', '~> 3.0'
 
-  gem.add_dependency 'apartment', '>= 1.0.0'
+  gem.add_dependency 'ros-apartment', '>= 1.0.0'
 end


### PR DESCRIPTION
Hi! I would like to propose a change in the `Apartment` gem. It looks like the project has been inactive for years (last commit 3 years ago) and isn't even fully compatible with Rails 6+.

I would suggestion to move to the drop-in replacement [`ros-apartment`](https://github.com/rails-on-services/apartment) gem. It's not maintained by the original maintainers, but is is actively maintained.

> Apartment drop in replacement gem
> 
> After having reached out via github issues and email directly, no replies ever came. Since we wanted to upgrade our application to Rails 6 we decided to fork and start some development to support Rails 6. Because we don't have access to the apartment gem itself, the solution was to release it under a different name but providing the exact same API as it was before.

This change is breaking, as that everyone who uses this also should switch to `ros-apartment` in the project, but the replacement works flawlessly in my own tests.